### PR TITLE
Use equality comparison for python version

### DIFF
--- a/script/bracey.py
+++ b/script/bracey.py
@@ -4,7 +4,7 @@ import sys
 
 python_version = int(sys.version[0])
 
-if python_version is 2:
+if python_version == 2:
     import urllib2 as requests
 else:
     from urllib import request as requests
@@ -20,7 +20,7 @@ def send(msg):
         print('bracey server is not running!')
         return
 
-    if python_version is not 2:
+    if python_version != 2:
         msg = msg.encode('utf-8')
 
     try:
@@ -60,6 +60,7 @@ def startServer():
             stdin=subprocess.PIPE)
     except Exception as e:
         print('could not start bracey server: ' + str(e))
+
 
 def stopServer():
     global bracey_server_process


### PR DESCRIPTION
I experienced the issue [mentioned here](https://robertbasic.com/blog/force-python-version-in-vim/)  after installing this plugin which led me to force using python3 by adding
```vim
if has('python3')
endif
```
to my vimrc. But after this addition the server connection was refused. And the cause turned out to be the integer comparison to test for the current python version used. I believe the issue is that `is` compares identity instead of value equality. Anyway, this change fixed it for me so I thought I'd give something back and issue a PR.

Thank you for a useful plugin!