### PR TITLE
Fix max default value for server port

### DIFF
--- a/plugin/bracey.vim
+++ b/plugin/bracey.vim
@@ -12,7 +12,9 @@ if !exists("g:bracey_server_path")
 endif
 
 if !exists("g:bracey_server_port")
-	let g:bracey_server_port = 13378 + (getpid() % 80000)
+	let offset = 13378
+	let port_max = 65536
+	let g:bracey_server_port = offset + (getpid() % (port_max-offset))
 endif
 
 if !exists("g:bracey_server_allow_remote_connections")


### PR DESCRIPTION
This seems to fix #15 for me. The idea is to create a default port number between 13378 and 65536 (which was the maximum allowed port number stated by the server error message).

I'm not sure what the 13378 number is but my guess is it is just to avoid the lower port numbers to avoid colliding with commonly used ports. Otherwise, giving it a more useful name would probably be a good idea. 

It might be that the maximum port number is different for different plattfoms so maybe that has to be dealt with as well, I haven't looked into that. 