### PR TITLE
fixes issue: Bracey can't launch browser on macOS vim

### DIFF
--- a/autoload/bracey.vim
+++ b/autoload/bracey.vim
@@ -32,7 +32,7 @@ endfunction
 function! bracey#startBrowser(url)
 	if g:bracey_browser_command == 0
 		if has("unix")
-			if system("uname -s") == "Darwin"
+			if f"{system('uname')}".split()[0] == "Darwin"
 				call system('open '.a:url.' &')
 			else
 				call system('xdg-open '.a:url.' &')


### PR DESCRIPTION
Another option would be using the re library

`>>> re.sub('\s+',' ',system('uname'))`

but this fix doesn't require any additional libraries to be imported