### PR TITLE
fixes an issue where vim on Mac could launch browser.

### DIFF
--- a/autoload/bracey.vim
+++ b/autoload/bracey.vim
@@ -32,7 +32,7 @@ endfunction
 function! bracey#startBrowser(url)
 	if g:bracey_browser_command == 0
 		if has("unix")
-			if system("uname -s") == "Darwin"
+			if system("uname")[0] == "Darwin"
 				call system('open '.a:url.' &')
 			else
 				call system('xdg-open '.a:url.' &')


### PR DESCRIPTION
Could technically be fixed by using 
`>>> re.sub('\s+',' ',myString)`

but this does not require any external modules