### PR TITLE
Bracey macOS browser launching error fix

### DIFF
--- a/autoload/bracey.vim
+++ b/autoload/bracey.vim
@@ -32,7 +32,7 @@ endfunction
 function! bracey#startBrowser(url)
 	if g:bracey_browser_command == 0
 		if has("unix")
-			if system("uname -s") == "Darwin"
+			if system("uname")[0] == "Darwin"
 				call system('open '.a:url.' &')
 			else
 				call system('xdg-open '.a:url.' &')

--- a/autoload/bracey.vim
+++ b/autoload/bracey.vim
@@ -32,7 +32,7 @@ endfunction
 function! bracey#startBrowser(url)
 	if g:bracey_browser_command == 0
 		if has("unix")
-			if system("uname")[0] == "Darwin"
+			if system('uname') =~ "Darwin"
 				call system('open '.a:url.' &')
 			else
 				call system('xdg-open '.a:url.' &')


### PR DESCRIPTION

fixes the issue where Bracey couldn't launch web browsers on macOS running devices.