### PR TITLE
Replace CSS parser with postcss

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -4,18 +4,18 @@
   "description": "",
   "main": "bracey.js",
   "dependencies": {
-    "css": "^2.2.1",
-    "csslint": "^0.10.0",
+    "csslint": "^1.0.5",
     "domhandler": "^2.3.0",
     "domutils": "^1.5.1",
     "htmlhint": "^0.11.0",
     "htmlparser2": "^3.9.0",
     "mime": "^1.3.4",
-    "websocket": "^1.0.22"
+    "postcss": "^7.0.32",
+    "websocket": "^1.0.32"
   },
   "devDependencies": {
     "chai": "*",
-    "mocha": "*"
+    "mocha": "^8.1.3"
   },
   "scripts": {
     "test": "mocha"

--- a/server/test/cssfile.js
+++ b/server/test/cssfile.js
@@ -22,7 +22,7 @@ describe('cssfile', function(){
 		it('calls callback with errors', function(done){
 			var invalidCss = 'body{ background: red color: white}';
 			file = new cssfile(invalidCss, 'can be whatever', function(err){
-				err.should.not.be.null;
+				expect(err).to.not.be.null;
 				done();
 			});
 		});


### PR DESCRIPTION
Partially fixes #36.

https://www.npmjs.com/package/css doesn't support newer CSS features. When encountering newer CSS like CSS3 variables or certain grid syntax, the server blows up because the parser returns undefined. `postcss` doesn't have this issue.

There is an additional wrinkle here as mentioned in #36:
> csslint doesn't support some newer features, notably CSS3 variables. So even though postcss works, csslint causes bracey to show false positives.

so with this PR, the parsing works but csslint will still cause bracey to blow up.

It looks like csslint is dead (see https://github.com/CSSLint/csslint/issues/720), so the solution appears to be either replace it with [stylelint](https://github.com/stylelint/stylelint) or simply remove csslint from bracey.

I'm not sure this PR will get any response but if there is interest, we can discuss the linting issues.