### PR TITLE
fix the custom browser command

### DIFF
--- a/autoload/bracey.vim
+++ b/autoload/bracey.vim
@@ -31,7 +31,7 @@ function! bracey#start()
 endfunction
 
 function! bracey#startBrowser(url)
-	if g:bracey_browser_command == 0
+	if type(g:bracey_browser_command) == type(0)
 		if has("unix")
 			if system("uname -s") =~ "Darwin"
 				call system('open '.a:url.' &')


### PR DESCRIPTION
In vim documentation `usr_41.txt`

>    When comparing a string with a number, the string is first converted to a
>   number.  This is a bit tricky, because when a string doesn't look like a
> number, the number zero is used.  Example: >
>
>	:if 0 == "one"
>	:  echo "yes"
>	:endif
>
> This will echo "yes", because "one" doesn't look like a number, thus it is
> converted to the number zero.

So, for [`g:bracey_browser_command`](https://github.com/turbio/bracey.vim/blob/457933c107db65ff7e2695e07209a9a2934544b7/autoload/bracey.vim#L34), we can't compare it with a number . If we insist use one variable to determine use default command or custom command by user, we can compare by their type.